### PR TITLE
Fix overflow in Date+SAP.swift

### DIFF
--- a/Sources/DVB/Date+SAP.swift
+++ b/Sources/DVB/Date+SAP.swift
@@ -3,7 +3,7 @@ import Foundation
 internal extension Date {
     /// Generate a date of the format `/Date(1487458060455+0100)/`
     var sapPattern: String {
-        let millis = Int(self.timeIntervalSince1970 * 1000)
+        let millis = Int64(self.timeIntervalSince1970 * 1000)
         let timezone = TimeZone.current.secondsFromGMT() / 3600 * 100
         return String(format: "/Date(\(millis)+%04d)/", timezone)
     }


### PR DESCRIPTION
Hi Kilian. In development of my App, I experienced calculating with 
´´´
let millis = Int(self.timeIntervalSince1970 * 1000)
´´´
can create an overflow. Change this line as proposed to fix this issue.